### PR TITLE
商品購入周りのURL直打ちのページ遷移無効化

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :set_card, except: :show
   before_action :set_item, only: [:edit, :update,:show, :destroy, :buy, :purchase]
-  before_action :cant_move_buy_purchase, only: [:buy, :purchase]
+  before_action :cant_move_buy_purchase, only: [:edit, :buy, :purchase]
 
   def index
     @items = Item.all.includes(:user)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -54,26 +54,30 @@ class ItemsController < ApplicationController
   end
 
   def buy
-    @address = Address.find_by(user_id: current_user.id)
-    #Payjpの秘密鍵を取得しています
-    Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_SECRET_KEY]
-    #Payjpから顧客情報を取得しています
-    customer = Payjp::Customer.retrieve(@card.customer_id)
-    @card_information = customer.cards.retrieve(@card.card_id)
-    @card_brand = @card_information.brand
-    case @card_brand
-    when "Visa"
-      @card_src = "visa.gif"
-    when "MasterCard"
-      @card_src = "master.gif"
-    when "JCB"
-      @card_src = "jcb.gif"
-    when "American Express"
-      @card_src = "amex.gif"
-    when "Diners Club"
-      @card_src = "diners.gif"
-    when "Discover"
-      @card_src = "dc.gif"
+    if @item.user_id != current_user.id
+      @address = Address.find_by(user_id: current_user.id)
+      #Payjpの秘密鍵を取得しています
+      Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_SECRET_KEY]
+      #Payjpから顧客情報を取得しています
+      customer = Payjp::Customer.retrieve(@card.customer_id)
+      @card_information = customer.cards.retrieve(@card.card_id)
+      @card_brand = @card_information.brand
+      case @card_brand
+      when "Visa"
+        @card_src = "visa.gif"
+      when "MasterCard"
+        @card_src = "master.gif"
+      when "JCB"
+        @card_src = "jcb.gif"
+      when "American Express"
+        @card_src = "amex.gif"
+      when "Diners Club"
+        @card_src = "diners.gif"
+      when "Discover"
+        @card_src = "dc.gif"
+      end
+    else
+      redirect_to root_path
     end
   end
   #↑同じ記述がcardsコントローラにもあります

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -54,7 +54,7 @@ class ItemsController < ApplicationController
   end
 
   def buy
-    if @item.user_id != current_user.id
+    if (@item.user_id != current_user.id) && !(@item.buyer_id.present?)
       @address = Address.find_by(user_id: current_user.id)
       #Payjpの秘密鍵を取得しています
       Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_SECRET_KEY]
@@ -83,7 +83,7 @@ class ItemsController < ApplicationController
   #↑同じ記述がcardsコントローラにもあります
 
   def purchase
-    if @item.user_id != current_user.id
+    if (@item.user_id != current_user.id) && !(@item.buyer_id.present?)
       Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_SECRET_KEY]
 
       charge = Payjp::Charge.create(

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -83,17 +83,21 @@ class ItemsController < ApplicationController
   #↑同じ記述がcardsコントローラにもあります
 
   def purchase
-    Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_SECRET_KEY]
+    if @item.user_id != current_user.id
+      Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_SECRET_KEY]
 
-    charge = Payjp::Charge.create(
-      amount: @item.price,
-      customer: Payjp::Customer.retrieve(@card.customer_id),
-      currency: 'jpy'
-    )
+      charge = Payjp::Charge.create(
+        amount: @item.price,
+        customer: Payjp::Customer.retrieve(@card.customer_id),
+        currency: 'jpy'
+      )
 
-    @item_buyer = Item.find(params[:id])
-    @item_buyer.update(buyer_id: current_user.id)
-    redirect_to purchased_item_path
+      @item_buyer = Item.find(params[:id])
+      @item_buyer.update(buyer_id: current_user.id)
+      redirect_to purchased_item_path
+    else
+      redirect_to root_path
+    end
   end
 
   private

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -48,13 +48,13 @@
             = @item.postageplayer.name
         .ItemBox__buy
           -if user_signed_in?
-            -if current_user.id == @item.user_id
+            -if @item.buyer_id.present? 
+              = link_to "売り切れました",buy_item_path, class:"ItemBox__buy--btn Btn--red Disabled"
+            - elsif current_user.id == @item.user_id
               = link_to edit_item_path(params[:id]), class: "ItemBox__buy--btn" do
                 編集する
               = link_to item_path(@item), method: :delete, class: "ItemBox__buy--btn Btn--red" do
                 削除する
-            - elsif @item.buyer_id.present? 
-              = link_to "売り切れました",buy_item_path, class:"ItemBox__buy--btn Btn--red Disabled"
             - else
               = link_to buy_item_path, class: "ItemBox__buy--btn" do
                 購入する


### PR DESCRIPTION
#What
以下の不備を修正しました。
- 自身が出品した商品の購入画面へURLを直打ちしても飛べないようになっている
- 自身が出品した商品は、支払いを作成するアクション(Payjp::Charge.createをするアクション)を動かせないようになっている
- 一度購入された商品の購入画面へURLを直打ちしても飛べなくなっている
- 一度購入された商品は、支払いを作成するアクション(Payjp::Charge.createをするアクション)を動かせないようになっている

#Why
出品者自身が商品購入できないようにするため。
購入された商品が購入できないようにするため。